### PR TITLE
fix: remove redundant "api/" prefix from voucher fetch path to preven…

### DIFF
--- a/pages/admin/master/voucher/index.jsx
+++ b/pages/admin/master/voucher/index.jsx
@@ -326,7 +326,7 @@ export default function VoucherCrud() {
         noControlBar={false}
         searchable={true}
         fetchControl={{
-          path: 'api/admin/vouchers', // biar komponen internal fetch bisa pakai relative; tapi kita sudah fetch manual di atas juga
+          path: 'admin/vouchers', // hapus "api/" di sini supaya tidak menghasilkan "/api/api/..." saat komponen menambahkan prefix
           method: 'GET',
           headers: () => ({
             'Content-Type': 'application/json',


### PR DESCRIPTION
…t double prefixing